### PR TITLE
bump ens-contracts to v1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ensdomains/ens-contracts": "0.0.22",
+        "@ensdomains/ens-contracts": "1.1.4",
         "@hyperledger-labs/yui-ibc-solidity": "git+https://github.com/hyperledger-labs/yui-ibc-solidity.git#v0.3.26",
         "@openzeppelin/contracts": "^5.0.1",
         "base64": "git+https://github.com/datachainlab/base64.git#4d85607b18d981acff392d2e99ba654305552a97",
@@ -185,9 +185,9 @@
       "integrity": "sha512-92SfSiNS8XorgU7OUBHo/i1ZU7JV7iz/6bKuLPNVsMxV79/eI7fJR6jfJJc40zAHjs3ha+Xo965Idomlq3rqnw=="
     },
     "node_modules/@ensdomains/ens-contracts": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-0.0.22.tgz",
-      "integrity": "sha512-kNu7pp68/5KfJ5wkswnUS4NfI9Ek4zGi0nnNSmGf1WXs6BHU9NYRVR6NnoVzb1B+cZ658e1v2srTtvmBYYIYzg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-1.1.4.tgz",
+      "integrity": "sha512-kjdcjaznMtE2lwjAVTX2irs8mgNgJCVuB5hnhFhiMaO8dR/tlHQ5UhtZjhSYRhkZd0hLXYrMkXp6thnwpG+ltg==",
       "dependencies": {
         "@ensdomains/buffer": "^0.1.1",
         "@ensdomains/solsha1": "0.0.3",
@@ -1476,9 +1476,9 @@
       "integrity": "sha512-92SfSiNS8XorgU7OUBHo/i1ZU7JV7iz/6bKuLPNVsMxV79/eI7fJR6jfJJc40zAHjs3ha+Xo965Idomlq3rqnw=="
     },
     "@ensdomains/ens-contracts": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-0.0.22.tgz",
-      "integrity": "sha512-kNu7pp68/5KfJ5wkswnUS4NfI9Ek4zGi0nnNSmGf1WXs6BHU9NYRVR6NnoVzb1B+cZ658e1v2srTtvmBYYIYzg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-1.1.4.tgz",
+      "integrity": "sha512-kjdcjaznMtE2lwjAVTX2irs8mgNgJCVuB5hnhFhiMaO8dR/tlHQ5UhtZjhSYRhkZd0hLXYrMkXp6thnwpG+ltg==",
       "requires": {
         "@ensdomains/buffer": "^0.1.1",
         "@ensdomains/solsha1": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@hyperledger-labs/yui-ibc-solidity": "git+https://github.com/hyperledger-labs/yui-ibc-solidity.git#v0.3.26",
     "base64": "git+https://github.com/datachainlab/base64.git#4d85607b18d981acff392d2e99ba654305552a97",
     "solidity-datetime": "git+https://github.com/datachainlab/solidity-datetime.git#294fc244973cc5f9ec374713affde12c1403927c",
-    "@ensdomains/ens-contracts": "0.0.22"
+    "@ensdomains/ens-contracts": "1.1.4"
   },
   "devDependencies": {
     "solhint": "^4.0.0"


### PR DESCRIPTION
There is no implementational difference due to this version bump.

I checked that there are no changes in the following three sol files.
- BytesUtils.sol
- RSAVerify.sol
- ModexpPrecompile.sol

Checking steps: 
```
npm pack @ensdomains/ens-contracts@v0.0.22
npm pack @ensdomains/ens-contracts@v1.1.4
mkdir ensdomains-ens-contracts-0.0.22 ensdomains-ens-contracts-1.1.4
tar -xzf ensdomains-ens-contracts-0.0.22.tgz -C ensdomains-ens-contracts-0.0.22
tar -xzf ensdomains-ens-contracts-1.1.4.tgz -C ensdomains-ens-contracts-1.1.4
diff -qr --exclude=artifacts ensdomains-ens-contracts-0.0.22 ensdomains-ens-contracts-1.1.4 | grep -e BytesUtils -e RSAVerify -e ModexpPrecompile
```


